### PR TITLE
auto topic creation enabled

### DIFF
--- a/kq/pusher.go
+++ b/kq/pusher.go
@@ -27,10 +27,13 @@ type (
 
 func NewPusher(addrs []string, topic string, opts ...PushOption) *Pusher {
 	producer := &kafka.Writer{
-		Addr:        kafka.TCP(addrs...),
-		Topic:       topic,
+		Addr:  kafka.TCP(addrs...),
+		Topic: topic,
+		//todo move the follwoing to config kpusherConfig?
 		Balancer:    &kafka.LeastBytes{},
 		Compression: kafka.Snappy,
+		//if this is not set, the writer will not create a nonexistent topic
+		AllowAutoTopicCreation: true,
 	}
 	pusher := &Pusher{
 		produer: producer,
@@ -53,7 +56,7 @@ func (p *Pusher) Close() error {
 	if p.executor != nil {
 		p.executor.Flush()
 	}
-	
+
 	return p.produer.Close()
 }
 


### PR DESCRIPTION
Hi
Tested with Strimzi Kafka and was getting this error when pushing with Pusher.push which in turns calls Kafka.writer.writemessage.
`Unknown Topic Or Partition: the request is for a topic or partition that does not exist on this broker`

Apparently accoding to this: [segmentio](https://github.com/segmentio/kafka-go#missing-topic-creation-before-publication) the AllowAutoTopicCreation in Writer should be set to true.