### PR TITLE
feature: support sasl SCRAM-SHA-256 and SCRAM-SHA-512 authentication

### DIFF
--- a/example/kq/producer/produce.go
+++ b/example/kq/producer/produce.go
@@ -19,11 +19,11 @@ type message struct {
 }
 
 func main() {
-	pusher := kq.NewPusher([]string{
-		"127.0.0.1:19092",
-		"127.0.0.1:19092",
-		"127.0.0.1:19092",
-	}, "kq")
+	pusher := kq.NewPusher(kq.KqConf{
+		Brokers: []string{"127.0.0.1:19092", "127.0.0.1:19092", "127.0.0.1:19092"},
+		Topic:   "kq",
+	},
+	)
 
 	ticker := time.NewTicker(time.Millisecond)
 	for round := 0; round < 3; round++ {

--- a/kq/config.go
+++ b/kq/config.go
@@ -21,4 +21,5 @@ type KqConf struct {
 	Username    string `json:",optional"`
 	Password    string `json:",optional"`
 	ForceCommit bool   `json:",default=true"`
+	Mechanism   string `json:",optional"`
 }


### PR DESCRIPTION
with issue:  https://github.com/zeromicro/go-queue/issues/46

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=65348599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 2/5</h2>

The PR is not safe to merge until public constructor compatibility and unsupported SASL mechanism handling are addressed.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Constructor Breaks Existing Callers** <a href="https://github.com/zeromicro/go-queue/pull/48#discussion_r4032871402">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Invalid Mechanisms Disable Authentication** <a href="https://github.com/zeromicro/go-queue/pull/48#discussion_r4032871410">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Authentication Removes Compression** <a href="https://github.com/zeromicro/go-queue/pull/48#discussion_r4032871417">▶</a>

<h3>Summary</h3>

This PR adds configurable PLAIN, SCRAM-SHA-256, and SCRAM-SHA-512 authentication to Kafka producers and consumers, and bounds producer writes with a configurable timeout.

- Extends `KqConf` with authentication mechanism and push-timeout settings.
- Builds SASL-enabled Kafka transports and dialers for producers and consumers.
- Changes the public producer constructor to accept `KqConf`.
- Adds unit coverage for timeout resolution.
- Requires attention to constructor compatibility, invalid mechanism handling, and authenticated-producer compression.

<details open><summary>Diagram</summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  C[KqConf] --> U{Username and password set?}
  U -- No --> N[Unauthenticated writer or reader]
  U -- Yes --> M{Mechanism}
  M -- Empty --> P[SASL PLAIN]
  M -- SCRAM-SHA-256 --> S256[SASL SCRAM-SHA-256]
  M -- SCRAM-SHA-512 --> S512[SASL SCRAM-SHA-512]
  M -- Other non-empty value --> X[Nil SASL mechanism]
  P --> K[Kafka]
  S256 --> K
  S512 --> K
  N --> K
  X --> K
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(kq): bound Kafka push duration"](https://github.com/zeromicro/go-queue/commit/1cf0f4a0fea3e8d3370b71a3006100a73d367d04)</sub>

<!-- /greptile_comment -->