### PR TITLE
fix: producerNode.Delay func not wrap()

### DIFF
--- a/dq/consumernode.go
+++ b/dq/consumernode.go
@@ -1,6 +1,7 @@
 package dq
 
 import (
+	"errors"
 	"time"
 
 	"github.com/beanstalkd/go-beanstalk"
@@ -59,14 +60,25 @@ func (c *consumerNode) consumeEvents(consume Consume) {
 		}
 
 		// the error can only be beanstalk.NameError or beanstalk.ConnError
-		switch cerr := err.(type) {
-		case beanstalk.ConnError:
-			switch cerr.Err {
-			case beanstalk.ErrTimeout:
+		var cerr beanstalk.ConnError
+		switch {
+		case errors.As(err, &cerr):
+			switch {
+			case errors.Is(cerr.Err, beanstalk.ErrTimeout):
 				// timeout error on timeout, just continue the loop
-			case beanstalk.ErrBadChar, beanstalk.ErrBadFormat, beanstalk.ErrBuried, beanstalk.ErrDeadline,
-				beanstalk.ErrDraining, beanstalk.ErrEmpty, beanstalk.ErrInternal, beanstalk.ErrJobTooBig,
-				beanstalk.ErrNoCRLF, beanstalk.ErrNotFound, beanstalk.ErrNotIgnored, beanstalk.ErrTooLong:
+			case
+				errors.Is(cerr.Err, beanstalk.ErrBadChar),
+				errors.Is(cerr.Err, beanstalk.ErrBadFormat),
+				errors.Is(cerr.Err, beanstalk.ErrBuried),
+				errors.Is(cerr.Err, beanstalk.ErrDeadline),
+				errors.Is(cerr.Err, beanstalk.ErrDraining),
+				errors.Is(cerr.Err, beanstalk.ErrEmpty),
+				errors.Is(cerr.Err, beanstalk.ErrInternal),
+				errors.Is(cerr.Err, beanstalk.ErrJobTooBig),
+				errors.Is(cerr.Err, beanstalk.ErrNoCRLF),
+				errors.Is(cerr.Err, beanstalk.ErrNotFound),
+				errors.Is(cerr.Err, beanstalk.ErrNotIgnored),
+				errors.Is(cerr.Err, beanstalk.ErrTooLong):
 				// won't reset
 				logx.Error(err)
 			default:

--- a/dq/producer.go
+++ b/dq/producer.go
@@ -1,10 +1,8 @@
 package dq
 
 import (
-	"bytes"
 	"log"
 	"math/rand"
-	"strconv"
 	"strings"
 	"time"
 
@@ -56,9 +54,8 @@ func NewProducer(beanstalks []Beanstalk) Producer {
 }
 
 func (p *producerCluster) At(body []byte, at time.Time) (string, error) {
-	wrapped := p.wrap(body, at)
 	return p.insert(func(node Producer) (string, error) {
-		return node.At(wrapped, at)
+		return node.At(body, at)
 	})
 }
 
@@ -73,9 +70,8 @@ func (p *producerCluster) Close() error {
 }
 
 func (p *producerCluster) Delay(body []byte, delay time.Duration) (string, error) {
-	wrapped := p.wrap(body, time.Now().Add(delay))
 	return p.insert(func(node Producer) (string, error) {
-		return node.Delay(wrapped, delay)
+		return node.Delay(body, delay)
 	})
 }
 
@@ -155,12 +151,4 @@ func (p *producerCluster) insert(fn func(node Producer) (string, error)) (string
 	}
 
 	return "", be.Err()
-}
-
-func (p *producerCluster) wrap(body []byte, at time.Time) []byte {
-	var builder bytes.Buffer
-	builder.WriteString(strconv.FormatInt(at.UnixNano(), 10))
-	builder.WriteByte(timeSep)
-	builder.Write(body)
-	return builder.Bytes()
 }

--- a/example/dq/producer/cluster.go
+++ b/example/dq/producer/cluster.go
@@ -9,8 +9,16 @@ import (
 )
 
 func main() {
-	producer := dq.NewProducerNode("localhost:11300", "tube")
-
+	producer := dq.NewProducer([]dq.Beanstalk{
+		{
+			Endpoint: "localhost:11300",
+			Tube:     "tube",
+		},
+		{
+			Endpoint: "localhost:11300",
+			Tube:     "tube",
+		},
+	})
 	for i := 1000; i < 1005; i++ {
 		_, err := producer.Delay([]byte(strconv.Itoa(i)), time.Second*5)
 		if err != nil {


### PR DESCRIPTION
 `dq.NewProducerNode("localhost:11300", "tube")`  producer  through `Delay()` send  success. 
but consumer consume `unwrap()`  error,  because no  `wrap()` func

help to review it. thank!

@kevwan @kesonan