### PR TITLE
add nats queue，support default and jetstream mode

### DIFF
--- a/dq/producer.go
+++ b/dq/producer.go
@@ -33,8 +33,11 @@ type (
 	}
 )
 
+var rng *rand.Rand
+
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	source := rand.NewSource(time.Now().UnixNano())
+	rng = rand.New(source)
 }
 
 func NewProducer(beanstalks []Beanstalk) Producer {
@@ -117,7 +120,7 @@ func (p *producerCluster) getWriteNodes() []Producer {
 	}
 
 	nodes := p.cloneNodes()
-	rand.Shuffle(len(nodes), func(i, j int) {
+	rng.Shuffle(len(nodes), func(i, j int) {
 		nodes[i], nodes[j] = nodes[j], nodes[i]
 	})
 	return nodes[:replicaNodes]

--- a/example/natsq/consumer/consumer.go
+++ b/example/natsq/consumer/consumer.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/zeromicro/go-queue/natsq"
+)
+
+type MyConsumer struct {
+	Channel string
+}
+
+func (c *MyConsumer) HandleMessage(m *natsq.Msg) error {
+	fmt.Printf("%s Received %s's a message: %s\n", c.Channel, m.Subject, string(m.Data))
+	return nil
+}
+
+func main() {
+
+	mc1 := &MyConsumer{Channel: "vipUpgrade"}
+	mc2 := &MyConsumer{Channel: "taskFinish"}
+
+	c := &natsq.NatsConfig{
+		ServerUri: "nats://127.0.0.1:4222",
+	}
+
+	//JetMode
+	// cq := []*natsq.ConsumerQueue{
+	// 	{
+	// 		Consumer:   mc1,
+	// 		QueueName:  "vipUpgrade",
+	// 		StreamName: "ccc",
+	// 		Subjects:   []string{"ddd", "eee"},
+	// 	},
+	// 	{
+	// 		Consumer:   mc2,
+	// 		QueueName:  "taskFinish",
+	// 		StreamName: "ccc",
+	// 		Subjects:   []string{"ccc", "eee"},
+	// 	},
+	// }
+	//q := natsq.MustNewConsumerManager(c, cq, natsq.NatJetMode)
+
+	//DefaultMode
+	cq := []*natsq.ConsumerQueue{
+		{
+			Consumer:  mc1,
+			QueueName: "vipUpgrade",
+			Subjects:  []string{"ddd", "eee"},
+		},
+		{
+			Consumer:  mc2,
+			QueueName: "taskFinish",
+			Subjects:  []string{"ccc", "eee"},
+		},
+	}
+	q := natsq.MustNewConsumerManager(c, cq, natsq.NatDefaultMode)
+	q.Start()
+	defer q.Stop()
+}

--- a/example/natsq/publisher/publisher.go
+++ b/example/natsq/publisher/publisher.go
@@ -49,9 +49,11 @@ func main() {
 }
 
 func randSub() string {
-	rand.Seed(time.Now().UnixNano())
+	source := rand.NewSource(time.Now().UnixNano())
+    // 创建一个新的随机数生成器
+    rng := rand.New(source)
 	strings := []string{"ccc", "ddd", "eee"}
-	randomIndex := rand.Intn(len(strings))
+	randomIndex := rng.Intn(len(strings))
 	return strings[randomIndex]
 }
 

--- a/example/natsq/publisher/publisher.go
+++ b/example/natsq/publisher/publisher.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/zeromicro/go-queue/natsq"
+)
+
+func main() {
+
+	c := natsq.NatsConfig{
+		ServerUri: "127.0.0.1:4222",
+	}
+
+	// Default Mode
+	p, _ := natsq.NewDefaultProducer(&c)
+	for i := 0; i < 3; i++ {
+		payload := randBody()
+		err := p.Publish(randSub(), payload)
+		if err != nil {
+			log.Fatalf("Error publishing message: %v", err)
+		} else {
+			log.Printf("Published message: %s", string(payload))
+		}
+	}
+	p.Close()
+
+	// JetMode
+	j, _ := natsq.NewJetProducer(&c)
+	j.CreateOrUpdateStream(jetstream.StreamConfig{
+		Name:     "ccc",
+		Subjects: []string{"ccc", "ddd", "eee"},
+		Storage:  jetstream.FileStorage,
+		NoAck:    false,
+	})
+	for i := 0; i < 3; i++ {
+		payload := randBody()
+		err := j.Publish(randSub(), payload)
+		if err != nil {
+			log.Fatalf("Error publishing message: %v", err)
+		} else {
+			log.Printf("Published message: %s", string(payload))
+		}
+	}
+	j.Close()
+}
+
+func randSub() string {
+	rand.Seed(time.Now().UnixNano())
+	strings := []string{"ccc", "ddd", "eee"}
+	randomIndex := rand.Intn(len(strings))
+	return strings[randomIndex]
+}
+
+func randBody() []byte {
+	charSet := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	length := 10
+	result := make([]byte, length)
+	for i := range result {
+		result[i] = charSet[rand.Intn(len(charSet))]
+	}
+	return result
+}

--- a/example/stan/publisher/producer.go
+++ b/example/stan/publisher/producer.go
@@ -44,12 +44,13 @@ func main() {
 }
 
 func randSub() string {
-	rand.Seed(time.Now().UnixNano())
+	source := rand.NewSource(time.Now().UnixNano())
+    rng := rand.New(source)
 	charSet := "abc"
 	length := 1
 	result := make([]byte, length)
 	for i := range result {
-		result[i] = charSet[rand.Intn(len(charSet))]
+		result[i] = charSet[rng.Intn(len(charSet))]
 	}
 	return string(result)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/zeromicro/go-queue
 
-go 1.19
+go 1.20
 
 require (
 	github.com/beanstalkd/go-beanstalk v0.2.0
+	github.com/nats-io/nats.go v1.34.1
 	github.com/nats-io/stan.go v0.10.4
 	github.com/rabbitmq/amqp091-go v1.9.0
 	github.com/segmentio/kafka-go v0.4.38
@@ -27,7 +28,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	github.com/nats-io/nats-server/v2 v2.9.15 // indirect
 	github.com/nats-io/nats-streaming-server v0.25.3 // indirect
-	github.com/nats-io/nats.go v1.34.1 // indirect
 	github.com/nats-io/nkeys v0.4.7 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/openzipkin/zipkin-go v0.4.2 // indirect

--- a/natsq/config.go
+++ b/natsq/config.go
@@ -1,0 +1,11 @@
+package natsq
+
+import (
+	"github.com/nats-io/nats.go"
+)
+
+type NatsConfig struct {
+	ServerUri  string
+	ClientName string
+	Options    []nats.Option
+}

--- a/natsq/consumer.go
+++ b/natsq/consumer.go
@@ -1,0 +1,174 @@
+package natsq
+
+import (
+	"context"
+	"errors"
+	"log"
+	"sync"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/zeromicro/go-zero/core/logx"
+	"github.com/zeromicro/go-zero/core/queue"
+)
+
+const (
+	NatDefaultMode = iota
+	NatJetMode
+)
+
+type (
+	Msg struct {
+		Subject string
+		Data    []byte
+	}
+
+	ConsumeHandle func(m *Msg) error
+
+	// ConsumeHandler Consumer interface, used to define the methods required by the consumer
+	ConsumeHandler interface {
+		HandleMessage(m *Msg) error
+	}
+
+	// ConsumerQueue Consumer queue, used to maintain the relationship between a consumer queue
+	ConsumerQueue struct {
+		StreamName string                     // stream name
+		QueueName  string                     // queue name
+		Subjects   []string                   // Subscribe subject
+		Consumer   ConsumeHandler             // consumer object
+		JetOption  []jetstream.PullConsumeOpt // Jetstream configuration
+	}
+
+	// ConsumerManager Consumer manager for managing multiple consumer queues
+	ConsumerManager struct {
+		mutex    sync.RWMutex    // read-write lock
+		conn     *nats.Conn      // nats connect
+		mode     uint            // nats mode
+		queues   []ConsumerQueue // consumer queue list
+		options  []nats.Option   // Connection configuration items
+		doneChan chan struct{}   // close channel
+	}
+)
+
+// MustNewConsumerManager creates a new ConsumerManager instance.
+// It connects to NATS server, registers the provided consumer queues, and returns the ConsumerManager.
+// If any error occurs during the process, it logs the error and continues.
+func MustNewConsumerManager(cfg *NatsConfig, cq []*ConsumerQueue, mode uint) queue.MessageQueue {
+	sc, err := nats.Connect(cfg.ServerUri, cfg.Options...)
+	if err != nil {
+		logx.Errorf("failed to connect nats, error: %v", err)
+	}
+	cm := &ConsumerManager{
+		conn:     sc,
+		options:  cfg.Options,
+		mode:     mode,
+		doneChan: make(chan struct{}),
+	}
+	if len(cq) == 0 {
+		logx.Errorf("failed consumerQueue register to  nats, error: cq len is 0")
+	}
+	for _, item := range cq {
+		err = cm.registerQueue(item)
+		if err != nil {
+			logx.Errorf("failed to register nats, error: %v", err)
+		}
+	}
+
+	return cm
+}
+
+// Start starts consuming messages from all the registered consumer queues.
+// It launches a goroutine for each consumer queue to subscribe and process messages.
+// The method blocks until the doneChan is closed.
+func (cm *ConsumerManager) Start() {
+	cm.mutex.RLock()
+	defer cm.mutex.RUnlock()
+
+	if len(cm.queues) == 0 {
+		logx.Errorf("no consumer queues found")
+	}
+	for _, consumerQueue := range cm.queues {
+		go cm.subscribe(consumerQueue)
+	}
+	<-cm.doneChan
+}
+
+// Stop closes the NATS connection and stops the ConsumerManager.
+func (cm *ConsumerManager) Stop() {
+	if cm.conn != nil {
+		cm.conn.Close()
+	}
+}
+
+// registerQueue registers a new consumer queue with the ConsumerManager.
+// It validates the required fields of the ConsumerQueue and adds it to the list of queues.
+// If any required field is missing, it returns an error.
+func (cm *ConsumerManager) registerQueue(queue *ConsumerQueue) error {
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+
+	if cm.mode == NatJetMode && queue.StreamName == "" {
+		return errors.New("stream name is required")
+	}
+
+	if queue.QueueName == "" {
+		return errors.New("queue name is required")
+	}
+	if len(queue.Subjects) == 0 {
+		return errors.New("subject is required")
+	}
+	if queue.Consumer == nil {
+		return errors.New("consumer is required")
+	}
+
+	cm.queues = append(cm.queues, *queue)
+	return nil
+}
+
+// subscribe subscribes to the specified consumer queue and starts processing messages.
+// If the NATS mode is NatJetMode, it creates a JetStream consumer and consumes messages using the provided options.
+// If the NATS mode is NatDefaultMode, it subscribes to the specified subjects using the queue name.
+// The method blocks until the doneChan is closed.
+func (cm *ConsumerManager) subscribe(queue ConsumerQueue) {
+	ctx := context.Background()
+	if cm.mode == NatJetMode {
+		js, _ := jetstream.New(cm.conn)
+		stream, err := js.Stream(ctx, "ccc")
+		if err != nil {
+			log.Fatalf("Error creating stream: %v", err)
+			return
+		}
+		consumer, _ := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+			Name:           queue.QueueName,
+			AckPolicy:      jetstream.AckExplicitPolicy,
+			FilterSubjects: queue.Subjects,
+		})
+		consContext, subErr := consumer.Consume(func(msg jetstream.Msg) {
+			err := queue.Consumer.HandleMessage(&Msg{Subject: msg.Subject(), Data: msg.Data()})
+			if err != nil {
+				logx.Errorf("error handling message: %v", err.Error())
+			} else {
+				msg.Ack()
+			}
+		}, queue.JetOption...)
+		if subErr != nil {
+			logx.Errorf("error subscribing to queue %s: %v", queue.QueueName, subErr.Error())
+			return
+		}
+		defer consContext.Stop()
+	}
+	if cm.mode == NatDefaultMode {
+		for _, subject := range queue.Subjects {
+			cm.conn.QueueSubscribe(subject, queue.QueueName, func(m *nats.Msg) {
+				err := queue.Consumer.HandleMessage(&Msg{Subject: m.Subject, Data: m.Data})
+				if err != nil {
+					logx.Errorf("error handling message: %v", err.Error())
+				} else {
+					m.Ack()
+				}
+			})
+		}
+	}
+
+	<-cm.doneChan
+}

--- a/natsq/producer.go
+++ b/natsq/producer.go
@@ -1,0 +1,88 @@
+package natsq
+
+import (
+	"context"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+type DefaultProducer struct {
+	conn *nats.Conn
+}
+
+// NewDefaultProducer creates a new default NATS producer.
+// It takes a NatsConfig as input and returns a pointer to a DefaultProducer and an error.
+// It connects to the NATS server using the provided configuration.
+func NewDefaultProducer(c *NatsConfig) (*DefaultProducer, error) {
+	sc, err := nats.Connect(c.ServerUri, c.Options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DefaultProducer{
+		conn: sc,
+	}, nil
+}
+
+// Publish publishes a message with the specified subject and data using the default NATS producer.
+// It takes a subject string and data byte slice as input and returns an error if the publish fails.
+func (p *DefaultProducer) Publish(subject string, data []byte) error {
+	return p.conn.Publish(subject, data)
+}
+
+// Close closes the NATS connection of the default producer.
+func (p *DefaultProducer) Close() {
+	if p.conn != nil {
+		p.conn.Close()
+	}
+}
+
+type JetProducer struct {
+	conn *nats.Conn
+	js   jetstream.JetStream
+	ctx  context.Context
+}
+
+// NewJetProducer creates a new JetStream producer.
+// It takes a NatsConfig as input and returns a pointer to a JetProducer and an error.
+// It connects to the NATS server using the provided configuration and creates a new JetStream context.
+func NewJetProducer(c *NatsConfig) (*JetProducer, error) {
+	sc, err := nats.Connect(c.ServerUri, c.Options...)
+	if err != nil {
+		return nil, err
+	}
+	js, err := jetstream.New(sc)
+	if err != nil {
+		return nil, err
+	}
+	return &JetProducer{
+		conn: sc,
+		js:   js,
+	}, nil
+}
+
+// CreateOrUpdateStream creates or updates a JetStream stream with the specified configuration.
+// It takes a jetstream.StreamConfig as input and returns an error if the operation fails.
+func (j *JetProducer) CreateOrUpdateStream(config jetstream.StreamConfig) error {
+	_, err := j.js.CreateOrUpdateStream(j.ctx, config)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Publish publishes a message with the specified subject and data using the JetStream producer.
+// It takes a subject string and data byte slice as input and returns an error if the publish fails.
+func (j *JetProducer) Publish(subject string, data []byte) error {
+	_, err := j.js.Publish(j.ctx, subject, data)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close closes the NATS connection of the JetStream producer.
+func (j *JetProducer) Close() {
+	j.conn.Close()
+}


### PR DESCRIPTION
The current version requires golang version 1.20 and above.

nats has officially deprecated the nats-streaming mode, so this version cannot support stanq in the library.

The current version implements nats default publish-subscribe and JetStream-based publish definition.

The default mode publisher publishes messages that are not landed, and if the subscriber is not online, the messages are lost.
Jetstream mode , the message landing , to ensure that the message is not lost , the message landing in the storage of a variety of ways , see the official nats documents

The current version has not yet realized the Reply mode for publishing messages