### PR TITLE
fix: kq sync producer write message wait 1s issue

### DIFF
--- a/kq/pusher.go
+++ b/kq/pusher.go
@@ -67,6 +67,7 @@ func NewPusher(addrs []string, topic string, opts ...PushOption) *Pusher {
 
 	// if syncPush is true, return the pusher directly
 	if options.syncPush {
+		producer.BatchSize = 1
 		return pusher
 	}
 


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This change addresses an issue with synchronous message pushing in the Kafka pusher, eliminating a 1-second delay problem.

- Modified `kq/pusher.go` to set `BatchSize` to 1 when `syncPush` is true, ensuring immediate message sending without batching
- Improves responsiveness for synchronous push operations in Kafka messaging
- Resolves potential performance bottleneck for time-sensitive applications using synchronous push

<!-- /greptile_comment -->