### PR TITLE
feat: rabbitmq add PrefetcheCount and PrefetcheSize

### DIFF
--- a/rabbitmq/config.go
+++ b/rabbitmq/config.go
@@ -23,7 +23,9 @@ type ConsumerConf struct {
 	// cannot be delivered to consumers in this connection.
 	NoLocal bool `json:",default=false"`
 	// Whether to block processing
-	NoWait bool `json:",default=false"`
+	NoWait        bool `json:",default=false"`
+	PrefetchCount int  `json:",default=0"`
+	PrefetchSize  int  `json:",default=0"`
 }
 
 type RabbitSenderConf struct {

--- a/rabbitmq/listener.go
+++ b/rabbitmq/listener.go
@@ -43,6 +43,10 @@ func MustNewListener(listenerConf RabbitListenerConf, handler ConsumeHandler) qu
 
 func (q RabbitListener) Start() {
 	for _, que := range q.queues.ListenerQueues {
+		err := q.channel.Qos(que.PrefetchCount, que.PrefetchSize, false)
+		if err != nil {
+			log.Fatalf("failed to listener, error: %v", err)
+		}
 		msg, err := q.channel.Consume(
 			que.Name,
 			"",


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added RabbitMQ QoS (Quality of Service) settings to improve message consumption control through PrefetchCount and PrefetchSize parameters in the consumer configuration.

- Added `PrefetchCount` and `PrefetchSize` fields to `ConsumerConf` struct in `/rabbitmq/config.go` for controlling unacknowledged message limits
- Modified `/rabbitmq/listener.go` to implement QoS settings during channel setup
- Both parameters default to 0 (unlimited) in the configuration
- Consider adding more descriptive error messages for QoS setup failures



<sub>💡 (2/5) Greptile learns from your feedback when you react with 👍/👎!</sub>

<!-- /greptile_comment -->