### PR TITLE
chore: upgrade kafka-go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/nats-io/nats.go v1.34.1
 	github.com/nats-io/stan.go v0.10.4
 	github.com/rabbitmq/amqp091-go v1.10.0
-	github.com/segmentio/kafka-go v0.4.47
+	github.com/segmentio/kafka-go v0.4.48
 	github.com/stretchr/testify v1.9.0
 	github.com/zeromicro/go-zero v1.6.6
 	go.opentelemetry.io/otel v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMu
 github.com/redis/go-redis/v9 v9.5.3 h1:fOAp1/uJG+ZtcITgZOfYFmTKPE7n4Vclj1wZFgRciUU=
 github.com/redis/go-redis/v9 v9.5.3/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
-github.com/segmentio/kafka-go v0.4.47 h1:IqziR4pA3vrZq7YdRxaT3w1/5fvIH5qpCwstUanQQB0=
-github.com/segmentio/kafka-go v0.4.47/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
+github.com/segmentio/kafka-go v0.4.48 h1:9jyu9CWK4W5W+SroCe8EffbrRZVqAOkuaLd/ApID4Vs=
+github.com/segmentio/kafka-go v0.4.48/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Upgrade Kafka-go version for Kafka 4.0 compatibility.

<!-- greptile_comment -->

## Greptile Summary

This PR upgrades the `github.com/segmentio/kafka-go` dependency from version 0.4.47 to 0.4.48 to add Kafka 4.0 compatibility. The change consists of updating two files:

1. **go.mod**: Updates the dependency declaration from v0.4.47 to v0.4.48
2. **go.sum**: Updates the corresponding checksums for integrity verification

The kafka-go library is a critical dependency for the `kq` package in this codebase, which implements Kafka-based message queuing functionality. The `kq/queue.go` file specifically uses this library to provide a Kafka queue implementation through the `kafkaQueue` struct that implements the `queue.MessageQueue` interface.

This is a patch-level version bump (0.4.47 → 0.4.48) within the same minor version, which typically indicates bug fixes, performance improvements, and infrastructure updates without breaking API changes. The upgrade ensures that users of the go-queue framework can work with newer Kafka 4.0 deployments while benefiting from the latest bug fixes and improvements in the underlying Kafka client library.

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it's a patch version upgrade of a well-maintained library
- Score reflects that this is a conservative dependency update with no breaking changes expected and good compatibility track record
- Pay close attention to go.mod and go.sum files to ensure the checksums are correct, though they appear properly updated

<!-- /greptile_comment -->